### PR TITLE
Fix numerous processing bugs and improve platform guards

### DIFF
--- a/Sources/PicsMinifierApp/AppMain.swift
+++ b/Sources/PicsMinifierApp/AppMain.swift
@@ -44,9 +44,10 @@ struct PicsMinifierMainApp: App {
 		CrashLogger.shared.logInfo("App icons disabled to prevent crashes", context: "AppMain")
 
 		// Сбросим CSV-лог и начнём заново с новым форматом
-		let logURL = AppPaths.logCSVURL()
-		try? FileManager.default.removeItem(at: logURL)
-		_ = CSVLogger(logURL: logURL)
+                let logURL = AppPaths.logCSVURL()
+                if CSVLogger(logURL: logURL) == nil {
+                        CrashLogger.shared.logError("Failed to initialize CSV logger", context: "AppMain")
+                }
 		// Привяжем обновление прогресса
 		Task { @MainActor in
 			let dummyView = ContentView()

--- a/Sources/PicsMinifierApp/ContentView.swift
+++ b/Sources/PicsMinifierApp/ContentView.swift
@@ -15,9 +15,10 @@ struct ContentView: View {
 	@State var preserveMetadata: Bool = true
 	@State var convertToSRGB: Bool = false
 	@State var enableGifsicle: Bool = true
-	@State var sessionStats: SessionStats = .init()
-	@State var showingSettings: Bool = false
-	@State var isProcessing: Bool = false
+        @State var sessionStats: SessionStats = .init()
+        @State var showingSettings: Bool = false
+        @State var isProcessing: Bool = false
+        @State private var progressObserverTokens: [NSObjectProtocol] = []
 
 	var body: some View {
 		ZStack(alignment: .topTrailing) {
@@ -195,10 +196,13 @@ struct ContentView: View {
 				NSApp.appearance = nil
 			}
 		}
-		.onChange(of: showDockIcon) { newValue in
-			UserDefaults.standard.set(newValue, forKey: "ui.showDockIcon")
-			AppUIManager.shared.setDockIconVisible(newValue)
-		}
+                .onChange(of: showDockIcon) { newValue in
+                        UserDefaults.standard.set(newValue, forKey: "ui.showDockIcon")
+                        AppUIManager.shared.setDockIconVisible(newValue)
+                }
+                .onDisappear {
+                        Task { @MainActor in teardownProgressUpdates() }
+                }
 		.onChange(of: showMenuBarIcon) { newValue in
 			UserDefaults.standard.set(newValue, forKey: "ui.showMenuBarIcon")
 			AppUIManager.shared.setMenuBarIconVisible(newValue)

--- a/Sources/PicsMinifierCore/AppPaths.swift
+++ b/Sources/PicsMinifierCore/AppPaths.swift
@@ -1,25 +1,23 @@
 import Foundation
 
 public enum AppPaths {
-	public static func logsDirectory() -> URL {
-		let fm = FileManager.default
+        public static func logsDirectory() -> URL {
+                let fm = FileManager.default
 
-		// Safe access to application support directory with fallback
-		guard let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-			// Fallback to temporary directory if application support is unavailable
-			let tempDir = fm.temporaryDirectory.appendingPathComponent("PicsMinifier", isDirectory: true)
-			try? fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
-			return tempDir
-		}
+                let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                        ?? fm.temporaryDirectory
 
-		let dir = base.appendingPathComponent("PicsMinifier", isDirectory: true)
-		try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-		return dir
-	}
+                let appSupport = base.appendingPathComponent("PicsMinifier", isDirectory: true)
+                let logsDir = appSupport.appendingPathComponent("Logs", isDirectory: true)
 
-	public static func logCSVURL() -> URL {
-		logsDirectory().appendingPathComponent("history.csv")
-	}
+                try? fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+                return logsDir
+        }
+
+        public static func logCSVURL() -> URL {
+                logsDirectory().appendingPathComponent("compression_log.csv")
+        }
 }
 
 

--- a/Sources/PicsMinifierCore/CSVLogger.swift
+++ b/Sources/PicsMinifierCore/CSVLogger.swift
@@ -1,38 +1,111 @@
 import Foundation
 
 public final class CSVLogger {
-	private let logURL: URL
-	private let queue = DispatchQueue(label: "csv.logger.queue", qos: .utility)
+    private static let headerLine = "timestamp,sourceFormat,targetFormat,originalPath,outputPath,originalSizeBytes,newSizeBytes,bytesSaved,savedRatio,status,reason\n"
 
-	public init?(logURL: URL) {
-		self.logURL = logURL
-		let fm = FileManager.default
-		if !fm.fileExists(atPath: logURL.path) {
-			let initial = Self.composeCSV(processed: StatsStore.shared.allTimeProcessedCount,
-											  saved: StatsStore.shared.allTimeSavedBytes)
-			try? initial.write(to: logURL, options: [.atomic])
-		} else {
-			// Приводим к новому формату при инициализации
-			let initial = Self.composeCSV(processed: StatsStore.shared.allTimeProcessedCount,
-											  saved: StatsStore.shared.allTimeSavedBytes)
-			try? initial.write(to: logURL, options: [.atomic])
-		}
-	}
+    private let logURL: URL
+    private let queue = DispatchQueue(label: "com.picsminifier.csvlogger", qos: .utility)
+    private let dateFormatter: ISO8601DateFormatter
 
-	public func append(_ record: ProcessResult) {
-		queue.async {
-			let processed = StatsStore.shared.allTimeProcessedCount
-			let saved = StatsStore.shared.allTimeSavedBytes
-			let data = Self.composeCSV(processed: processed, saved: saved)
-			try? data.write(to: self.logURL, options: [.atomic])
-		}
-	}
+    public init?(logURL: URL) {
+        self.logURL = logURL
+        self.dateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
 
-	private static func composeCSV(processed: Int, saved: Int64) -> Data {
-		let header = "processedTotal,savedBytesTotal\n"
-		let body = "\(processed),\(saved)\n"
-		return (header + body).data(using: .utf8) ?? Data()
-	}
+        let directory = logURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            if !FileManager.default.fileExists(atPath: logURL.path) {
+                try Self.headerLine.write(to: logURL, atomically: true, encoding: .utf8)
+            } else {
+                try ensureHeaderExists()
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    public func append(_ record: ProcessResult) {
+        queue.async {
+            let line = self.composeLine(from: record)
+            guard let data = line.data(using: .utf8) else { return }
+
+            do {
+                if !FileManager.default.fileExists(atPath: self.logURL.path) {
+                    try Self.headerLine.write(to: self.logURL, atomically: true, encoding: .utf8)
+                }
+
+                let fileHandle = try FileHandle(forWritingTo: self.logURL)
+                defer { fileHandle.closeFile() }
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(data)
+            } catch {
+                // Fallback: rewrite the entire file atomically to avoid losing data
+                let existingData = (try? Data(contentsOf: self.logURL)) ?? Data()
+                let combined = existingData + data
+                try? combined.write(to: self.logURL, options: .atomic)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func ensureHeaderExists() throws {
+        let content = try String(contentsOf: logURL, encoding: .utf8)
+        if content.isEmpty {
+            try Self.headerLine.write(to: logURL, atomically: true, encoding: .utf8)
+            return
+        }
+
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let first = lines.first, first == Self.headerLine.trimmingCharacters(in: .newlines) else {
+            var remainder = content
+            if !remainder.hasSuffix("\n") {
+                remainder.append("\n")
+            }
+            let updated = Self.headerLine + remainder
+            try updated.write(to: logURL, atomically: true, encoding: .utf8)
+            return
+        }
+    }
+
+    private func composeLine(from result: ProcessResult) -> String {
+        let timestamp = dateFormatter.string(from: Date())
+        let savedBytes = max(0, result.originalSizeBytes - result.newSizeBytes)
+        let ratio: Double
+        if result.originalSizeBytes > 0 {
+            ratio = Double(savedBytes) / Double(result.originalSizeBytes)
+        } else {
+            ratio = 0
+        }
+
+        let savedRatio = String(format: "%.6f", ratio)
+
+        let fields: [String] = [
+            timestamp,
+            csvEscape(result.sourceFormat),
+            csvEscape(result.targetFormat),
+            csvEscape(result.originalPath),
+            csvEscape(result.outputPath),
+            String(result.originalSizeBytes),
+            String(result.newSizeBytes),
+            String(savedBytes),
+            savedRatio,
+            csvEscape(result.status),
+            csvEscape(result.reason ?? "")
+        ]
+
+        return fields.joined(separator: ",") + "\n"
+    }
+
+    private func csvEscape(_ field: String) -> String {
+        guard field.contains("\"") || field.contains(",") || field.contains("\n") else {
+            return field
+        }
+        return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
 }
-
-

--- a/Sources/PicsMinifierCore/CrashLogger.swift
+++ b/Sources/PicsMinifierCore/CrashLogger.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(os.log)
 import os.log
 
 /// Простая система логирования ошибок и крашей
@@ -84,6 +86,38 @@ public final class CrashLogger {
         try? header.write(to: logFileURL, atomically: true, encoding: .utf8)
     }
 }
+
+#else
+
+public final class CrashLogger {
+    public static let shared = CrashLogger()
+
+    private init() {}
+
+    public func logError(_ error: Error, context: String = "") {
+        print("[CrashLogger] ERROR in \(context): \(error.localizedDescription)")
+    }
+
+    public func logWarning(_ message: String, context: String = "") {
+        print("[CrashLogger] WARNING in \(context): \(message)")
+    }
+
+    public func logInfo(_ message: String, context: String = "") {
+        print("[CrashLogger] INFO in \(context): \(message)")
+    }
+
+    public func logCritical(_ message: String, context: String = "") {
+        print("[CrashLogger] CRITICAL in \(context): \(message)")
+    }
+
+    public func getLogFileURL() -> URL {
+        return FileManager.default.temporaryDirectory
+    }
+
+    public func clearLog() {}
+}
+
+#endif
 
 private extension DateFormatter {
     static let logFormatter: DateFormatter = {

--- a/Sources/PicsMinifierCore/FileWalker.swift
+++ b/Sources/PicsMinifierCore/FileWalker.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 
 public struct FileWalker {
@@ -41,5 +43,36 @@ public struct FileWalker {
 		]
 	}()
 }
+#else
+
+public struct FileWalker {
+        public init() {}
+
+        public func enumerateSupportedFiles(at url: URL) -> [URL] {
+                var results: [URL] = []
+                let fm = FileManager.default
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { return results }
+
+                if isDir.boolValue {
+                        if let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles]) {
+                                for case let fileURL as URL in enumerator {
+                                        if isSupported(fileURL) { results.append(fileURL) }
+                                }
+                        }
+                } else {
+                        if isSupported(url) { results.append(url) }
+                }
+
+                return results
+        }
+
+        private func isSupported(_ url: URL) -> Bool {
+                let supportedExtensions: Set<String> = ["jpg", "jpeg", "png", "bmp", "gif", "heic", "heif", "webp"]
+                return supportedExtensions.contains(url.pathExtension.lowercased())
+        }
+}
+
+#endif
 
 

--- a/Sources/PicsMinifierCore/GifsicleOptimizer.swift
+++ b/Sources/PicsMinifierCore/GifsicleOptimizer.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if canImport(Darwin)
 import Darwin
 
 public final class GifsicleOptimizer {
@@ -93,5 +95,19 @@ public final class GifsicleOptimizer {
 		return nil
 	}
 }
+
+#else
+
+public final class GifsicleOptimizer {
+        public init() {}
+
+        public func optimize(inputURL: URL, outputURL: URL) -> ProcessResult {
+                let originalSize = (try? FileManager.default.attributesOfItem(atPath: inputURL.path)[.size] as? NSNumber)?.int64Value ?? 0
+                let format = inputURL.pathExtension.lowercased()
+                return ProcessResult(sourceFormat: format, targetFormat: format, originalPath: inputURL.path, outputPath: inputURL.path, originalSizeBytes: originalSize, newSizeBytes: originalSize, status: "skipped", reason: "gifsicle-unavailable")
+        }
+}
+
+#endif
 
 

--- a/Sources/PicsMinifierCore/WebPEncoder.swift
+++ b/Sources/PicsMinifierCore/WebPEncoder.swift
@@ -1,82 +1,94 @@
 import Foundation
+
+#if canImport(ImageIO) && canImport(UniformTypeIdentifiers)
 import ImageIO
 import UniformTypeIdentifiers
 import WebPShims
 
 public enum WebPAvailability {
-	case systemCodec
-	case embedded
-	case unavailable
+        case systemCodec
+        case embedded
+        case unavailable
 }
 
 public final class WebPEncoder {
-	public init() {}
+        public init() {}
 
-	public func availability() -> WebPAvailability {
-		let webp = UTType(importedAs: "org.webmproject.webp").identifier as CFString
-		if let types = CGImageDestinationCopyTypeIdentifiers() as? [CFString], types.contains(webp) {
-			return .systemCodec
-		}
-		return webp_embedded_available() != 0 ? .embedded : .unavailable
-	}
+        public func availability() -> WebPAvailability {
+                let webp = UTType(importedAs: "org.webmproject.webp").identifier as CFString
+                if let types = CGImageDestinationCopyTypeIdentifiers() as? [CFString], types.contains(webp) {
+                        return .systemCodec
+                }
+                return webp_embedded_available() != 0 ? .embedded : .unavailable
+        }
 
-	public func encodeRGBA(_ rgba: Data, width: Int, height: Int, quality: Int) -> Data? {
-		var outputPtr: UnsafeMutablePointer<UInt8>? = nil
-		var outputSize: Int = 0
-		let stride = width * 4
-		let q: Float = Float(quality)
+        public func encodeRGBA(_ rgba: Data, width: Int, height: Int, quality: Int) -> Data? {
+                var outputPtr: UnsafeMutablePointer<UInt8>? = nil
+                var outputSize: Int = 0
+                let stride = width * 4
+                let q: Float = Float(quality)
 
-		// Ensure memory cleanup in all exit paths
-		defer {
-			if let ptr = outputPtr {
-				webp_free_buffer(ptr)
-			}
-		}
+                defer {
+                        if let ptr = outputPtr {
+                                webp_free_buffer(ptr)
+                        }
+                }
 
-		let success: Int = rgba.withUnsafeBytes { rawBuf in
-			guard let base = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
-			var sizeT: size_t = 0
-			let res = webp_encode_rgba(base, Int32(width), Int32(height), Int32(stride), q, &outputPtr, &sizeT)
-			outputSize = Int(sizeT)
-			return Int(res)
-		}
+                let success: Int = rgba.withUnsafeBytes { rawBuf in
+                        guard let base = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+                        var sizeT: size_t = 0
+                        let res = webp_encode_rgba(base, Int32(width), Int32(height), Int32(stride), q, &outputPtr, &sizeT)
+                        outputSize = Int(sizeT)
+                        return Int(res)
+                }
 
-		guard success != 0, let outNonNil = outputPtr, outputSize > 0 else {
-			return nil
-		}
+                guard success != 0, let outNonNil = outputPtr, outputSize > 0 else {
+                        return nil
+                }
 
-		// Copy data before cleanup
-		let data = Data(bytes: outNonNil, count: outputSize)
-		return data
-	}
+                return Data(bytes: outNonNil, count: outputSize)
+        }
 
-	public func decodeRGBA(_ webpData: Data) -> (rgba: Data, width: Int, height: Int, stride: Int)? {
-		var outPtr: UnsafeMutablePointer<UInt8>? = nil
-		var w: Int32 = 0
-		var h: Int32 = 0
-		var stride: Int32 = 0
+        public func decodeRGBA(_ webpData: Data) -> (rgba: Data, width: Int, height: Int, stride: Int)? {
+                var outPtr: UnsafeMutablePointer<UInt8>? = nil
+                var w: Int32 = 0
+                var h: Int32 = 0
+                var stride: Int32 = 0
 
-		// Ensure memory cleanup in all exit paths
-		defer {
-			if let ptr = outPtr {
-				webp_free_buffer(ptr)
-			}
-		}
+                defer {
+                        if let ptr = outPtr {
+                                webp_free_buffer(ptr)
+                        }
+                }
 
-		let ok: Int = webpData.withUnsafeBytes { rawBuf in
-			guard let base = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
-			return Int(webp_decode_rgba(base, webpData.count, &outPtr, &w, &h, &stride))
-		}
+                let ok: Int = webpData.withUnsafeBytes { rawBuf in
+                        guard let base = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return 0 }
+                        return Int(webp_decode_rgba(base, webpData.count, &outPtr, &w, &h, &stride))
+                }
 
-		guard ok != 0, let out = outPtr, w > 0, h > 0, stride > 0 else {
-			return nil
-		}
+                guard ok != 0, let out = outPtr, w > 0, h > 0, stride > 0 else {
+                        return nil
+                }
 
-		let byteCount = Int(stride) * Int(h)
-		// Copy data before cleanup
-		let data = Data(bytes: out, count: byteCount)
-		return (data, Int(w), Int(h), Int(stride))
-	}
+                let byteCount = Int(stride) * Int(h)
+                let data = Data(bytes: out, count: byteCount)
+                return (data, Int(w), Int(h), Int(stride))
+        }
+}
+#else
+
+public enum WebPAvailability {
+        case unavailable
 }
 
+public final class WebPEncoder {
+        public init() {}
 
+        public func availability() -> WebPAvailability { .unavailable }
+
+        public func encodeRGBA(_ data: Data, width: Int, height: Int, quality: Int) -> Data? { nil }
+
+        public func decodeRGBA(_ webpData: Data) -> (rgba: Data, width: Int, height: Int, stride: Int)? { nil }
+}
+
+#endif

--- a/Tests/PicsMinifierAppTests/SecurityFixesTests.swift
+++ b/Tests/PicsMinifierAppTests/SecurityFixesTests.swift
@@ -7,8 +7,14 @@ final class SecurityFixesTests: XCTestCase {
 
     func testPathValidation() throws {
         // Valid paths should pass
-        XCTAssertNoThrow(try SecurityUtils.validateFilePath("/Users/test/image.jpg"))
-        XCTAssertNoThrow(try SecurityUtils.validateFilePath("/tmp/temp.png"))
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser.path
+        let homeImage = URL(fileURLWithPath: homeDirectory).appendingPathComponent("Pictures/test.jpg").path
+        XCTAssertNoThrow(try SecurityUtils.validateFilePath(homeImage))
+
+        let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("temp.png").path
+        XCTAssertNoThrow(try SecurityUtils.validateFilePath(tempFile))
+
+        XCTAssertNoThrow(try SecurityUtils.validateFilePath("/Volumes/Drive/image.png"))
 
         // Directory traversal should fail
         XCTAssertThrowsError(try SecurityUtils.validateFilePath("/Users/test/../../../etc/passwd"))
@@ -17,6 +23,9 @@ final class SecurityFixesTests: XCTestCase {
         // Invalid paths should fail
         XCTAssertThrowsError(try SecurityUtils.validateFilePath("/root/secret"))
         XCTAssertThrowsError(try SecurityUtils.validateFilePath("/System/important"))
+
+        let siblingHome = URL(fileURLWithPath: homeDirectory).deletingLastPathComponent().appendingPathComponent("otheruser/file.jpg").path
+        XCTAssertThrowsError(try SecurityUtils.validateFilePath(siblingHome))
     }
 
     func testArgumentSanitization() throws {


### PR DESCRIPTION
## Summary
- Rebuild CSV logging so log files persist, use per-file schema, and append asynchronously
- Harden compression and statistics updates: revert non-improving outputs, respect environment overrides, and expose cancellation hooks
- Strengthen SecurityUtils validation/sanitization while making process execution and platform-specific services safe on non-macOS builds
- Provide Linux fallbacks for macOS-only modules (CompressionService, SmartCompressor, WebPEncoder, etc.) so tests can compile where possible

## Testing
- `swift test` *(fails: depends on Apple frameworks such as SwiftUI/CoreGraphics that are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d189c9208328bd5a36491751a7be